### PR TITLE
Unable to read decoded json inside the Docker push

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ Fork from https://github.com/urcomputeringpal/actions-docker
 - Create a Secret on your repository named `GCLOUD_SERVICE_ACCOUNT_KEY` (Settings > Secrets) with the contents of:
 
 ```shell
+# Linux
 cat path-to/key.json | base64 -w 0
+
+# MacOS
+cat path-to/key.json | base64 -b 0
 ```
 
 - That's it! The GitHub Actions in this repository read this Secret and provide the correct values to the Docker daemon by default if present. If a Secret isn't present, `build` _may_ succeed but `push` will return an error!

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Fork from https://github.com/urcomputeringpal/actions-docker
 - Create a Secret on your repository named `GCLOUD_SERVICE_ACCOUNT_KEY` (Settings > Secrets) with the contents of:
 
 ```shell
-echo -n "$(cat path-to/downloaded-key/4a276e9e5862.json)" | base64
+cat path-to/key.json | base64 -w 0
 ```
 
 - That's it! The GitHub Actions in this repository read this Secret and provide the correct values to the Docker daemon by default if present. If a Secret isn't present, `build` _may_ succeed but `push` will return an error!

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -7,14 +7,13 @@ set -e
 : ${ARGS:=} # Default: empty build args
 : ${TAG:=$GITHUB_SHA}
 : ${DEFAULT_BRANCH_TAG:=true}
-: ${LATEST:=false}
+: ${LATEST:=true}
 
 docker build $ARGS -t $IMAGE:$TAG .
 docker tag $IMAGE:$TAG $GCLOUD_REGISTRY/$IMAGE:$TAG
 
 if [ $LATEST = true ]; then
-  docker build $ARGS -t $IMAGE:latest .
-  docker tag $IMAGE:latest $GCLOUD_REGISTRY/$IMAGE:latest
+  docker tag $IMAGE:$TAG $GCLOUD_REGISTRY/$IMAGE:latest
 fi
 
 if [ "$DEFAULT_BRANCH_TAG" = "true" ]; then

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -4,12 +4,19 @@ set -e
 
 : ${GCLOUD_REGISTRY:=gcr.io}
 : ${IMAGE:=$GITHUB_REPOSITORY}
+: ${ARGS:=} # Default: empty build args
 : ${TAG:=$GITHUB_SHA}
 : ${DEFAULT_BRANCH_TAG:=true}
+: ${LATEST:=false}
 
-docker build -t $IMAGE:latest -t $IMAGE:$TAG .
+docker build $ARGS -t $IMAGE:$TAG .
 docker tag $IMAGE:$TAG $GCLOUD_REGISTRY/$IMAGE:$TAG
-docker tag $IMAGE:latest $GCLOUD_REGISTRY/$IMAGE:latest
+
+if [ $LATEST = true ]; then
+  docker build $ARGS -t $IMAGE:latest .
+  docker tag $IMAGE:latest $GCLOUD_REGISTRY/$IMAGE:latest
+fi
+
 if [ "$DEFAULT_BRANCH_TAG" = "true" ]; then
   BRANCH=$(echo $GITHUB_REF | rev | cut -f 1 -d / | rev)
   if [ "$BRANCH" = "master" ]; then # TODO

--- a/push/entrypoint.sh
+++ b/push/entrypoint.sh
@@ -6,7 +6,7 @@ set -e
 : ${IMAGE:=$GITHUB_REPOSITORY}
 : ${TAG:=$GITHUB_SHA}
 : ${DEFAULT_BRANCH_TAG:=true}
-: ${LATEST:=false}
+: ${LATEST:=true}
 
 if [ -n "${GCLOUD_SERVICE_ACCOUNT_KEY}" ]; then
   echo "Logging into gcr.io with GCLOUD_SERVICE_ACCOUNT_KEY..."

--- a/push/entrypoint.sh
+++ b/push/entrypoint.sh
@@ -6,6 +6,7 @@ set -e
 : ${IMAGE:=$GITHUB_REPOSITORY}
 : ${TAG:=$GITHUB_SHA}
 : ${DEFAULT_BRANCH_TAG:=true}
+: ${LATEST:=false}
 
 if [ -n "${GCLOUD_SERVICE_ACCOUNT_KEY}" ]; then
   echo "Logging into gcr.io with GCLOUD_SERVICE_ACCOUNT_KEY..."
@@ -16,5 +17,8 @@ else
   echo "GCLOUD_SERVICE_ACCOUNT_KEY was empty, not performing auth" 1>&2
 fi
 
-docker push $GCLOUD_REGISTRY/$IMAGE
-docker push $GCLOUD_REGISTRY/$IMAGE:latest
+docker push $GCLOUD_REGISTRY/$IMAGE:$TAG
+
+if [ $LATEST = true ]; then
+  docker push $GCLOUD_REGISTRY/$IMAGE:latest
+fi


### PR DESCRIPTION
I followed the instruction on how to encode the key to base64 but it shows some error.

I debugged it and figured out that the issue was on the `echo` command use while encoding the key.

When pushing the image, it shows the error below.
`ERROR: (gcloud.auth.activate-service-account) Could not read json file /tmp/key.json: Invalid control character at: line 5 column 46 (char 179)`