### PR TITLE
Allow us to push the real sha

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:232.0.0
+FROM google/cloud-sdk:290.0.1-alpine
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:290.0.1-alpine
+FROM google/cloud-sdk:alpine
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/build/action.yml
+++ b/build/action.yml
@@ -3,7 +3,7 @@ description: 'Build docker images that can be uploaded to gcr.io'
 author: 'Soren Mathiasen'
 runs:
   using: 'docker'
-  image: 'docker://eu.gcr.io/tradeshift-base/gcr-docker-builder:1.0.0'
+  image: 'docker://eu.gcr.io/tradeshift-public/gcr-docker-builder:1.0.0'
 branding:
   icon: 'check-square'
   color: 'blue'

--- a/build/action.yml
+++ b/build/action.yml
@@ -3,7 +3,7 @@ description: 'Build docker images that can be uploaded to gcr.io'
 author: 'Soren Mathiasen'
 runs:
   using: 'docker'
-  image: 'docker://eu.gcr.io/tradeshift-public/gcr-docker-builder:1.0.1'
+  image: 'docker://eu.gcr.io/tradeshift-public/gcr-docker-builder:1.0.2'
 branding:
   icon: 'check-square'
   color: 'blue'

--- a/build/action.yml
+++ b/build/action.yml
@@ -1,0 +1,9 @@
+name: 'GCR Docker builder'
+description: 'Build docker images that can be uploaded to gcr.io'
+author: 'Soren Mathiasen'
+runs:
+  using: 'docker'
+  image: 'docker://eu.gcr.io/tradeshift-base/gcr-docker-builder:1.0.0'
+branding:
+  icon: 'check-square'
+  color: 'blue'

--- a/build/action.yml
+++ b/build/action.yml
@@ -3,7 +3,7 @@ description: 'Build docker images that can be uploaded to gcr.io'
 author: 'Soren Mathiasen'
 runs:
   using: 'docker'
-  image: 'docker://eu.gcr.io/tradeshift-public/gcr-docker-builder:1.0.0'
+  image: 'docker://eu.gcr.io/tradeshift-public/gcr-docker-builder:1.0.1'
 branding:
   icon: 'check-square'
   color: 'blue'

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -23,6 +23,8 @@ fi
 echo "Building $GCLOUD_REGISTRY/$IMAGE:$TAG in $WORKDIR"
 docker build $ARGS -t $GCLOUD_REGISTRY/$IMAGE:$TAG $WORKDIR
 
+# Always tag with the sha
+docker tag $GCLOUD_REGISTRY/$IMAGE:$TAG $GCLOUD_REGISTRY/$IMAGE:${GITHUB_SHA}
 if [ $LATEST = true ]; then
   docker tag $GCLOUD_REGISTRY/$IMAGE:$TAG $GCLOUD_REGISTRY/$IMAGE:latest
 fi

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-: ${GCLOUD_REGISTRY:=gcr.io}
+: ${GCLOUD_REGISTRY:=eu.gcr.io/tradeshift-base}
 : ${IMAGE:=$GITHUB_REPOSITORY}
 : ${ARGS:=} # Default: empty build args
 : ${TAG:=$GITHUB_SHA}

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -8,8 +8,9 @@ set -e
 : ${TAG:=$GITHUB_SHA}
 : ${DEFAULT_BRANCH_TAG:=true}
 : ${LATEST:=true}
-echo "Building $GCLOUD_REGISTRY/$IMAGE:$TAG"
-docker build $ARGS -t $GCLOUD_REGISTRY/$IMAGE:$TAG .
+: ${WORKDIR:=.}
+echo "Building $GCLOUD_REGISTRY/$IMAGE:$TAG in $WORKDIR"
+docker build $ARGS -t $GCLOUD_REGISTRY/$IMAGE:$TAG $WORKDIR
 
 if [ $LATEST = true ]; then
   docker tag $GCLOUD_REGISTRY/$IMAGE:$TAG $GCLOUD_REGISTRY/$IMAGE:latest

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -8,17 +8,16 @@ set -e
 : ${TAG:=$GITHUB_SHA}
 : ${DEFAULT_BRANCH_TAG:=true}
 : ${LATEST:=true}
-
-docker build $ARGS -t $IMAGE:$TAG .
-docker tag $IMAGE:$TAG $GCLOUD_REGISTRY/$IMAGE:$TAG
+echo "Building $GCLOUD_REGISTRY/$IMAGE:$TAG"
+docker build $ARGS -t $GCLOUD_REGISTRY/$IMAGE:$TAG .
 
 if [ $LATEST = true ]; then
-  docker tag $IMAGE:$TAG $GCLOUD_REGISTRY/$IMAGE:latest
+  docker tag $GCLOUD_REGISTRY/$IMAGE:$TAG $GCLOUD_REGISTRY/$IMAGE:latest
 fi
 
 if [ "$DEFAULT_BRANCH_TAG" = "true" ]; then
   BRANCH=$(echo $GITHUB_REF | rev | cut -f 1 -d / | rev)
   if [ "$BRANCH" = "master" ]; then # TODO
-    docker tag $IMAGE:$TAG $GCLOUD_REGISTRY/$IMAGE:$BRANCH
+    docker tag $GCLOUD_REGISTRY/$IMAGE:$TAG $GCLOUD_REGISTRY/$IMAGE:$BRANCH
   fi
 fi

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -9,6 +9,17 @@ set -e
 : ${DEFAULT_BRANCH_TAG:=true}
 : ${LATEST:=true}
 : ${WORKDIR:=.}
+
+
+if [ -n "${GCLOUD_SERVICE_ACCOUNT_KEY}" ]; then
+  echo "Logging into gcr.io with GCLOUD_SERVICE_ACCOUNT_KEY..."
+  echo ${GCLOUD_SERVICE_ACCOUNT_KEY} | base64 -d > /tmp/key.json
+  gcloud auth activate-service-account --quiet --key-file /tmp/key.json
+  gcloud auth configure-docker --quiet
+else
+  echo "GCLOUD_SERVICE_ACCOUNT_KEY was empty, not performing auth" 1>&2
+fi
+
 echo "Building $GCLOUD_REGISTRY/$IMAGE:$TAG in $WORKDIR"
 docker build $ARGS -t $GCLOUD_REGISTRY/$IMAGE:$TAG $WORKDIR
 

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-: ${GCLOUD_REGISTRY:=eu.gcr.io/tradeshift-base}
+: ${GCLOUD_REGISTRY:=eu.gcr.io}
 : ${IMAGE:=$GITHUB_REPOSITORY}
 : ${ARGS:=} # Default: empty build args
 : ${TAG:=$GITHUB_SHA}

--- a/push/Dockerfile
+++ b/push/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:232.0.0
+FROM google/cloud-sdk:290.0.1-alpine
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/push/Dockerfile
+++ b/push/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:290.0.1-alpine
+FROM google/cloud-sdk:alpine
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/push/action.yml
+++ b/push/action.yml
@@ -3,7 +3,7 @@ description: 'Build docker images that can be uploaded to gcr.io'
 author: 'Soren Mathiasen'
 runs:
   using: 'docker'
-  image: 'docker://eu.gcr.io/tradeshift-public/gcr-docker-push:1.0.1'
+  image: 'docker://eu.gcr.io/tradeshift-public/gcr-docker-push:1.0.2'
 branding:
   icon: 'check-square'
   color: 'blue'

--- a/push/action.yml
+++ b/push/action.yml
@@ -1,0 +1,9 @@
+name: 'GCR Docker builder'
+description: 'Build docker images that can be uploaded to gcr.io'
+author: 'Soren Mathiasen'
+runs:
+  using: 'docker'
+  image: 'docker://eu.gcr.io/tradeshift-base/gcr-docker-push:1.0.0'
+branding:
+  icon: 'check-square'
+  color: 'blue'

--- a/push/action.yml
+++ b/push/action.yml
@@ -3,7 +3,7 @@ description: 'Build docker images that can be uploaded to gcr.io'
 author: 'Soren Mathiasen'
 runs:
   using: 'docker'
-  image: 'docker://eu.gcr.io/tradeshift-base/gcr-docker-push:1.0.0'
+  image: 'docker://eu.gcr.io/tradeshift-public/gcr-docker-push:1.0.0'
 branding:
   icon: 'check-square'
   color: 'blue'

--- a/push/action.yml
+++ b/push/action.yml
@@ -3,7 +3,7 @@ description: 'Build docker images that can be uploaded to gcr.io'
 author: 'Soren Mathiasen'
 runs:
   using: 'docker'
-  image: 'docker://eu.gcr.io/tradeshift-public/gcr-docker-push:1.0.0'
+  image: 'docker://eu.gcr.io/tradeshift-public/gcr-docker-push:1.0.1'
 branding:
   icon: 'check-square'
   color: 'blue'

--- a/push/entrypoint.sh
+++ b/push/entrypoint.sh
@@ -20,7 +20,7 @@ fi
 echo "Pushing $GCLOUD_REGISTRY/$IMAGE:$TAG"
 echo "Pushing $GCLOUD_REGISTRY/$IMAGE:$GITHUB_SHA"
 docker push $GCLOUD_REGISTRY/$IMAGE:$TAG
-
+docker push $GCLOUD_REGISTRY/$IMAGE:$GITHUB_SHA
 if [ $LATEST = true ]; then
   docker push $GCLOUD_REGISTRY/$IMAGE:latest
 fi

--- a/push/entrypoint.sh
+++ b/push/entrypoint.sh
@@ -10,7 +10,7 @@ set -e
 
 if [ -n "${GCLOUD_SERVICE_ACCOUNT_KEY}" ]; then
   echo "Logging into gcr.io with GCLOUD_SERVICE_ACCOUNT_KEY..."
-  echo ${GCLOUD_SERVICE_ACCOUNT_KEY} | base64 --decode --ignore-garbage > /tmp/key.json
+  echo ${GCLOUD_SERVICE_ACCOUNT_KEY} | base64 -d > /tmp/key.json
   gcloud auth activate-service-account --quiet --key-file /tmp/key.json
   gcloud auth configure-docker --quiet
 else

--- a/push/entrypoint.sh
+++ b/push/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-: ${GCLOUD_REGISTRY:=gcr.io}
+: ${GCLOUD_REGISTRY:=eu.gcr.io/tradeshift-base}
 : ${IMAGE:=$GITHUB_REPOSITORY}
 : ${TAG:=$GITHUB_SHA}
 : ${DEFAULT_BRANCH_TAG:=true}

--- a/push/entrypoint.sh
+++ b/push/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-: ${GCLOUD_REGISTRY:=eu.gcr.io/tradeshift-base}
+: ${GCLOUD_REGISTRY:=eu.gcr.io}
 : ${IMAGE:=$GITHUB_REPOSITORY}
 : ${TAG:=$GITHUB_SHA}
 : ${DEFAULT_BRANCH_TAG:=true}

--- a/push/entrypoint.sh
+++ b/push/entrypoint.sh
@@ -17,6 +17,8 @@ else
   echo "GCLOUD_SERVICE_ACCOUNT_KEY was empty, not performing auth" 1>&2
 fi
 
+echo "Pushing $GCLOUD_REGISTRY/$IMAGE:$TAG"
+echo "Pushing $GCLOUD_REGISTRY/$IMAGE:$GITHUB_SHA"
 docker push $GCLOUD_REGISTRY/$IMAGE:$TAG
 
 if [ $LATEST = true ]; then


### PR DESCRIPTION
Github actions creates a merge commit before the run is started. This can
be overridden with
```
      steps:
        - uses: actions/checkout@v2
          with:
            ref: ${{ github.event.pull_request.head.sha }}
```

But then we need to use that SHA inside the build and push too...